### PR TITLE
Unit test hike

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,10 @@ group :development, :test do
   gem 'simplecov'
 end
 
+group :test do
+  gem 'factory_girl_rails'
+end
+
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,11 @@ GEM
     docile (1.1.5)
     erubis (2.7.0)
     execjs (2.6.0)
+    factory_girl (4.7.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.7.0)
+      factory_girl (~> 4.7.0)
+      railties (>= 3.0.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     i18n (0.7.0)
@@ -182,6 +187,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.2.0)
   byebug
   coffee-rails (~> 4.1.0)
+  factory_girl_rails
   jbuilder (~> 2.0)
   jquery-rails
   pg
@@ -197,4 +203,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/spec/factories/hike.rb
+++ b/spec/factories/hike.rb
@@ -1,0 +1,4 @@
+FactoryGirl.define do
+  factory :hike do
+  end
+end

--- a/spec/models/hike_spec.rb
+++ b/spec/models/hike_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Hike, type: :model do
+  subject(:hike) { FactoryGirl.create :hike }
+
+  it 'has a valid factory' do
+    expect(hike).to be_valid
+  end
+
+  describe 'associations' do
+    it 'has many trips' do
+      ar = described_class.reflect_on_association(:trips)
+      expect(ar.macro) == :has_many
+    end
+
+    it 'has many hikers' do
+      ar = described_class.reflect_on_association(:hikers)
+      expect(ar.macro) == :has_many
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require "simplecov"
 require "rails_helper"
 
-SimpleCov.start do
+SimpleCov.start 'rails' do
   add_filter 'spec/'
 end
 


### PR DESCRIPTION
Issue #3 

This change adds a unit test for the hikes model. It could serve as a template for other unit tests.

It also leverages Simplecov's `'rails'` pattern to the test setup. This gives more detailed coverage information specifically for Rails apps.